### PR TITLE
Add [election_deadline] to Follower state

### DIFF
--- a/src/raft.proto
+++ b/src/raft.proto
@@ -20,9 +20,9 @@ package raft;
 
 message Message {
     oneof t {
-        RequestVoteRequest request_vote_request = 1;
-        RequestVoteResponse request_vote_response = 2;
-        AppendEntriesRequest append_entries_request = 3;
+        RequestVoteRequest    request_vote_request    = 1;
+        RequestVoteResponse   request_vote_response   = 2;
+        AppendEntriesRequest  append_entries_request  = 3;
         AppendEntriesResponse append_entries_response = 4;
     }
 }
@@ -102,8 +102,9 @@ message CandidateState {
 }
 
 message FollowerState {
-  optional int32 voted_for = 1; 
-  optional int32 current_leader = 2;
+  optional int32 voted_for          = 1; 
+  optional int32 current_leader     = 2;
+  required double election_deadline = 3;
 }
 
 // This message keeps track of when a heartbeat 

--- a/src/raft_helper.mli
+++ b/src/raft_helper.mli
@@ -39,6 +39,7 @@ module Follower : sig
     ?voted_for:int -> 
     ?log:Raft_pb.log_entry list ->
     configuration:Raft_pb.configuration -> 
+    now:float -> 
     id:int -> 
     unit -> 
     Raft_pb.state 
@@ -46,7 +47,7 @@ module Follower : sig
       follower state. 
     *)
 
-  val become : ?current_leader:int -> term:int -> Raft_pb.state -> Raft_pb.state
+  val become : ?current_leader:int -> term:int -> now:float -> Raft_pb.state -> Raft_pb.state
   (** [become ~current_leader state term] return the new follower state. 
       
       {ul
@@ -159,10 +160,12 @@ end (* Configuration *)
 
 module Follow_up_action : sig
 
+  (*
   val new_election_wait : Raft_pb.state -> Raft_pb.follow_up_action
   (** [new_election_wait state] returns a [Wait_for_rpc] follow action for 
       a new election. 
     *)
+  *)
   
   val existing_election_wait : float -> float -> Raft_pb.follow_up_action 
   (** [existing_election_wait election_deadline now] returns [Wait_for_rpc] follow up 

--- a/src/raft_pb.mli
+++ b/src/raft_pb.mli
@@ -74,6 +74,7 @@ type candidate_state = {
 type follower_state = {
   voted_for : int option;
   current_leader : int option;
+  election_deadline : float;
 }
 
 type configuration = {
@@ -201,6 +202,7 @@ val default_candidate_state :
 val default_follower_state : 
   ?voted_for:int option ->
   ?current_leader:int option ->
+  ?election_deadline:float ->
   unit ->
   follower_state
 (** [default_follower_state ()] is the default value for type [follower_state] *)


### PR DESCRIPTION
- Follower must actively keeps track of the deadline for
  the next election and therefore we introduce the missing
  field in the FollowerState message.
