### PR TITLE
Global cache  and update committed data

### DIFF
--- a/src/raft.proto
+++ b/src/raft.proto
@@ -504,7 +504,7 @@ message TimeoutEvent {
 message Notification {
   
   message CommitedData {
-    repeated string ids = 1;
+    repeated LogEntry rev_log_entries = 1;
   }
 
   message NewLeader {

--- a/src/raft_pb.mli
+++ b/src/raft_pb.mli
@@ -145,7 +145,7 @@ type timeout_event = {
 }
 
 type notification_commited_data = {
-  ids : string list;
+  rev_log_entries : log_entry list;
 }
 
 type notification_new_leader = {
@@ -334,7 +334,7 @@ val default_timeout_event :
 (** [default_timeout_event ()] is the default value for type [timeout_event] *)
 
 val default_notification_commited_data : 
-  ?ids:string list ->
+  ?rev_log_entries:log_entry list ->
   unit ->
   notification_commited_data
 (** [default_notification_commited_data ()] is the default value for type [notification_commited_data] *)

--- a/src/raft_revlogcache.mli
+++ b/src/raft_revlogcache.mli
@@ -48,6 +48,8 @@ val replace : local_cache -> global_cache -> global_cache
     raises [Failure] if [local_cache] cannot be matched.
   *)
 
+val from_list : local_cache list -> global_cache
+
 (** {2 Local Cache} *)
 
 val make : ?until:int -> since:int -> Raft_pb.log_entry list -> local_cache

--- a/src/raft_state.ml
+++ b/src/raft_state.ml
@@ -233,14 +233,14 @@ let notifications before after =
   let notifications = 
     if acommit_index > bcommit_index
     then 
-      let rec aux ids = function 
-        | {index;id;_ }::tl -> 
+      let rec aux rev_log_entries = function 
+        | ({index;_ } as log_entry) ::tl -> 
             if index > acommit_index 
-            then aux ids tl 
+            then aux rev_log_entries tl 
             else 
               if index = bcommit_index
-              then ids 
-              else aux (id :: ids) tl 
+              then rev_log_entries
+              else aux (log_entry :: rev_log_entries) tl 
         | [] ->  
           assert(bcommit_index = 0); 
           (* If commit_index is different than 0 then this means 
@@ -256,9 +256,9 @@ let notifications before after =
            * The other is a plain bug, all entries between 2 commit_index should be 
            * in the log.
            *) 
-          ids 
+          rev_log_entries 
       in
-      (Committed_data {ids = aux [] after.log})::notifications 
+      (Committed_data {rev_log_entries = aux [] after.log})::notifications 
     else 
       notifications
   in 
@@ -350,8 +350,8 @@ let compaction state =
           end 
     ) (([], [], false), next_indices) state.global_cache in 
 
-    let is_compacted = function | {rev_log_entries = Compacted _ ; _ } -> true | _ -> false in 
-    let is_expanded  = function | {rev_log_entries = Expanded  _ ; _ } -> true | _ -> false in 
+    let is_compacted : log_interval -> bool = function | {rev_log_entries = Compacted _ ; _ } -> true | _ -> false in 
+    let is_expanded  : log_interval -> bool = function | {rev_log_entries = Expanded  _ ; _ } -> true | _ -> false in 
 
     let c = List.filter is_expanded  c in 
     let e = List.filter is_compacted e in 

--- a/tests/test.ml
+++ b/tests/test.ml
@@ -789,7 +789,10 @@ let ()  =
 
   assert(State.is_leader server0);
   assert(1 = server0.commit_index);
-  assert((Committed_data {ids = ["01"]})::[] = notifications);
+  begin match notifications with 
+  | (Committed_data { rev_log_entries = [{id = "01"; _ }]})::[] -> ()
+  | _ -> assert(false)
+  end; 
     (*
      * server1 has replicated the log successfully so this means
      * that a majority of servers have done the replication.
@@ -899,7 +902,10 @@ let ()  =
      * with [index = 2].
      *)
 
-  assert((Committed_data {ids = ["01"]})::[] = notifications);
+  begin match notifications with 
+  | (Committed_data { rev_log_entries = [{id = "01"; _ }]})::[] -> ()
+  | _ -> assert(false)
+  end; 
   assert(1 = server1.commit_index);
     (*
      * The [Append_entries] request contained the [commit_index]
@@ -941,7 +947,10 @@ let ()  =
 
   assert(State.is_leader server0);
 
-  assert((Committed_data {ids = ["02"]})::[] = notifications);
+  begin match notifications with 
+  | (Committed_data { rev_log_entries = [{id = "02"; _ }]})::[] -> ()
+  | _ -> assert(false)
+  end; 
   assert(2 = server0.commit_index);
     (*
      * A successfull replication is enough for a majority.
@@ -1029,7 +1038,10 @@ let ()  =
 
   assert(State.is_follower server1);
 
-  assert((Committed_data {ids = ["02"]})::[] = notifications);
+  begin match notifications with 
+  | (Committed_data { rev_log_entries = [{id = "02"; _ }]})::[] -> ()
+  | _ -> assert(false)
+  end; 
   assert(2 = server1.commit_index);
    (*
     * server1 is updating its commit index based on latest
@@ -1057,7 +1069,10 @@ let ()  =
   in
 
   assert(State.is_follower server2);
-  assert((Committed_data {ids = ["01"]})::[] = notications);
+  begin match notifications with 
+  | (Committed_data { rev_log_entries = [{id = "02"; _ }]})::[] -> ()
+  | _ -> assert(false)
+  end; 
   assert(1 = server2.commit_index);
    (*
     * server2 is updating its commit index based on latest
@@ -1148,7 +1163,10 @@ let ()  =
      *)
 
   assert(2 = server2.commit_index);
-  assert((Committed_data {ids = ["02"]})::[] = notifications);
+  begin match notifications with 
+  | (Committed_data { rev_log_entries = [{id = "02"; _ }]})::[] -> ()
+  | _ -> assert(false)
+  end; 
     (* This time the commit_index is 2 since both [log_entry] with
      * [index = 2] has been replicated and the [leader_commit] is equal
      * to 2.
@@ -1609,7 +1627,10 @@ let ()  =
   assert(State.is_leader server1);
   assert(3 = server1.current_term);
 
-  assert((Committed_data {ids = ["03"]})::[] = notifications);
+  begin match notifications with 
+  | (Committed_data { rev_log_entries = [{id = "03"; _ }]})::[] -> ()
+  | _ -> assert(false)
+  end; 
   assert(3 = server1.commit_index);
     (*
      * The 3rd [log_entry] has been replicated one one other
@@ -1716,10 +1737,10 @@ let ()  =
      *)
 
   assert(1 = List.length notifications);
-  begin match notifications with
-  | (Committed_data {ids = ["03"] }) :: [] -> ()
-  | _ -> assert(false);
-  end;
+  begin match notifications with 
+  | (Committed_data { rev_log_entries = [{id = "03"; _ }]})::[] -> ()
+  | _ -> assert(false)
+  end; 
 
   begin match msgs with
   | (Append_entries_response r, 1) :: [] -> (
@@ -1753,11 +1774,11 @@ let ()  =
   assert([] = msgs);
   assert(1 = List.length notifications);
 
-  begin match notifications with
-  | (Committed_data {ids}) :: [] ->
-    assert(2 = List.length ids);
-  | _ -> assert(false);
-  end;
+  begin match notifications with 
+  | (Committed_data { rev_log_entries }) :: [] -> 
+    assert(2 = List.length rev_log_entries)
+  | _ -> assert(false)
+  end; 
 
   (*
    * The test of the cache is not something that a client API should
@@ -1839,10 +1860,12 @@ let ()  =
 
   assert(5 = server2.commit_index);
   assert(1 = List.length notifications);
-  begin match notifications with
-  | (Committed_data {ids})::[] -> assert(2 = List.length ids)
+  begin match notifications with 
+  | (Committed_data { rev_log_entries }) :: [] -> 
+    assert(2 = List.length rev_log_entries)
   | _ -> assert(false)
-  end;
+  end; 
+
     (* commit index updated to match server1.
      * and therefore a new notification with
      * 2 entries is expected


### PR DESCRIPTION
- Add `from_list` to build the global cache form a list of `log_intervals`
- Change `Commited_data` to be in terms of log entries.
